### PR TITLE
Placeholder PR -- do not merge -- feat: set service_name from Log Group and hostname from Log Stream suffix

### DIFF
--- a/src/function.py
+++ b/src/function.py
@@ -526,6 +526,8 @@ def _package_log_payload(data):
                         "logStream": entry["logStream"],
                         "logGroup": entry["logGroup"],
                     },
+                    "service_name": entry["logGroup"],
+                    "hostname": entry["logStream"].split("/")[-1],
                 }
             },
             "logs": log_messages,

--- a/src/function.py
+++ b/src/function.py
@@ -526,7 +526,7 @@ def _package_log_payload(data):
                         "logStream": entry["logStream"],
                         "logGroup": entry["logGroup"],
                     },
-                    "service_name": entry["logGroup"],
+                    "service_name": entry["logGroup"].split("/")[-1],
                     "hostname": entry["logStream"].split("/")[-1].split("]")[-1],
                 }
             },

--- a/src/function.py
+++ b/src/function.py
@@ -527,7 +527,7 @@ def _package_log_payload(data):
                         "logGroup": entry["logGroup"],
                     },
                     "service_name": entry["logGroup"],
-                    "hostname": entry["logStream"].split("/")[-1],
+                    "hostname": entry["logStream"].split("/")[-1].split("]")[-1],
                 }
             },
             "logs": log_messages,


### PR DESCRIPTION
This sets the New Relic Logs attribute `service_name` to the CloudWatch
Log Group, and sets the attribute `hostname` to the trailing portion of
the CloudWatch Log Stream ("/" delimited, the ECS task ID for ECS logs).
Without this change, both of those fields are N/A in NR Logs if the
application is not setting them in the log message.